### PR TITLE
Fix unbound TEMP_DIR variable in install.sh EXIT trap

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -7,11 +7,13 @@ set -euo pipefail
 # One-command install:
 #   curl -sL https://raw.githubusercontent.com/AgriciDaniel/claude-blog/main/install.sh | bash
 
+# Declared outside main() so the EXIT trap can access it after main() returns
+TEMP_DIR=""
+
 main() {
     local SKILL_DIR="${HOME}/.claude/skills"
     local AGENT_DIR="${HOME}/.claude/agents"
     local SCRIPT_DIR
-    local TEMP_DIR=""
 
     echo ""
     echo "  ╔══════════════════════════════════════╗"


### PR DESCRIPTION
## Summary
- `TEMP_DIR` was declared as `local` inside `main()`, but the `EXIT` trap runs **after** `main()` returns — at which point local variables are out of scope
- Combined with `set -u` (nounset), this causes `bash: line 129: TEMP_DIR: unbound variable` when installing via `curl | bash`
- Fix: move `TEMP_DIR=""` declaration to global scope before `main()`

## Reproduction
```bash
curl -fsSL https://raw.githubusercontent.com/AgriciDaniel/claude-blog/main/install.sh | bash
# Installation completes, but prints: bash: line 129: TEMP_DIR: unbound variable
```

## Test plan
- [ ] Run `curl -fsSL ... | bash` — should complete without error
- [ ] Run script from local clone — should still work correctly