### PR TITLE
fix(readme): correct marketplace name to agricidaniel-blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ claude-blog is a Claude Code skill ecosystem for creating, optimizing, and manag
 /plugin marketplace add AgriciDaniel/claude-blog
 
 # Install plugin
-/plugin install claude-blog@AgriciDaniel-claude-blog
+/plugin install claude-blog@agricidaniel-blog
 ```
 
 **Recommended: clone then verify before installing** (lets you inspect


### PR DESCRIPTION
Fix `/plugin install` command. Old name `AgriciDaniel-claude-blog` not resolved by Claude, correct name is `agricidaniel-blog`

**Test plan**
- [x] Run `/plugin install claude-blog@agricidaniel-blog` and verify install succeeds