### PR TITLE
fix: harden _has_module against ImportError for dotted module names (issue #29)

### DIFF
--- a/scripts/blog_preflight.py
+++ b/scripts/blog_preflight.py
@@ -159,7 +159,13 @@ def _gate_result(gate: int, name: str, passed: bool, violations: Optional[list] 
 
 
 def _has_module(name: str) -> bool:
-    return importlib.util.find_spec(name) is not None
+    # find_spec raises ImportError/ValueError for a dotted name whose parent
+    # package is absent (e.g. "google.genai" when "google" isn't installed),
+    # instead of returning None. Treat any resolution failure as "not present".
+    try:
+        return importlib.util.find_spec(name) is not None
+    except (ImportError, ValueError):
+        return False
 
 
 def _project_root() -> Path:


### PR DESCRIPTION
## Summary

`_has_module("google.genai")` crashes with `ModuleNotFoundError: No module named 'google'` on machines where the `google` package is not installed. This is the default state for most users.

**Root cause**: `importlib.util.find_spec("google.genai")` tries to import the parent package `google` to resolve the submodule. When `google` is absent, that `__import__` raises `ModuleNotFoundError` (a subclass of `ImportError`). The current helper doesn't guard against this.

**Fix**: Wrap the lookup in a try/except and treat any resolution failure as "not present":

```python
def _has_module(name: str) -> bool:
    try:
        return importlib.util.find_spec(name) is not None
    except (ImportError, ValueError):
        return False
```

## Verification

Without the fix, running `blog_preflight.py --strict` on a machine without `google` installed crashes at Gate 1. After the fix, it passes Gate 1 with the expected "no configured image-gen path" warning.
