### PR TITLE
fix(ci): provision Claude CLI for release validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,14 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # SHA-pinned, closes VULN-503
 
+      - name: Set up Node.js 22
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4, SHA-pinned
+        with:
+          node-version: "22"
+
+      - name: Install Claude Code CLI
+        run: npm install --global --no-audit --no-fund @anthropic-ai/claude-code@2.1.218
+
       - name: Validate SKILL.md frontmatter
         run: |
           python3 - <<'PY'
@@ -152,20 +160,7 @@ jobs:
           "
 
       - name: Run `claude plugin validate`
-        run: |
-          if command -v claude >/dev/null 2>&1; then
-            claude plugin validate .
-          else
-            case "${GITHUB_REF_NAME}" in
-              main|master|release/*|v*)
-                echo "claude CLI is required for protected and release refs"
-                exit 1
-                ;;
-              *)
-                echo "claude CLI not available on runner; schema checks above still ran"
-                ;;
-            esac
-          fi
+        run: claude plugin validate .
 
   lint-markdown:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ Public distribution normalization and a collision-safe patch release.
   checkout-independent verification for PowerShell.
 - Declared Pillow for presentation workflows and completed the development
   dependency set used by rendering, image, PageSpeed, and Search Console tests.
+- Made plugin validation deterministic on pull requests and protected branches
+  by installing an exact Claude Code CLI version in CI.
 
 ## [2.1.0] - 2026-07-23
 


### PR DESCRIPTION
## Summary

- provision Node.js 22 on the plugin-validation runner
- install the exact Claude Code CLI version `2.1.218`
- run `claude plugin validate .` on pull requests and protected branches without a skip path
- include the CI reliability correction in the v2.1.1 changelog

## Root cause

The protected-branch workflow required the Claude CLI but never installed it. Pull requests skipped validation when the executable was absent, so the defect only appeared after the v2.1.1 release PR merged to `main`.

## Validation

- exact `@anthropic-ai/claude-code@2.1.218` package validates the marketplace locally
- `python3 -m pytest tests/ -q`: 318 passed, 1 intentional skip
- prose lint: pass
- public-release validator: 0 errors across 22 surfaces
- consistency graph: 0 errors; 4 unchanged advisory orphan warnings
- `git diff --check`: pass