### PR TITLE
feat(image): add Atlas Cloud hero fallback

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -73,7 +73,7 @@ plugin straddles. Findings against any of these are in scope:
 | ID | Boundary | Threats |
 |---|---|---|
 | T1 | CLI args / skill invocation prompts → Python scripts | shell injection, path traversal, DoS |
-| T2 | External API responses (Google APIs) → JSON parse → reports | response forgery, secret cache leak |
+| T2 | External API responses (Google and Atlas Cloud APIs) → JSON parse or image download → local artifacts | response forgery, secret leak, SSRF through output URLs |
 | T3 | NotebookLM browser session state → fs | session pickle tampering, credential leak |
 | T4 | Env vars (`GOOGLE_AI_API_KEY` etc.) → MCP subprocess (npx) | env leak in subprocess, MCP impersonation |
 | T5 | `SKILL.md` / `agents/*.md` → loaded by Claude as instructions | prompt injection, tool abuse |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_No unreleased changes._
+### Added
+
+- Added Atlas Cloud as an optional hero-image fallback with single-submit task
+  creation, bounded prediction polling, and exact output resizing.
 
 ## [2.1.1] - 2026-07-23
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -206,7 +206,7 @@ docstring, JSON output, and stdlib-only or narrowly-pinned dependencies.
 | `cognitive_load.py` | Per-section concept-density analyzer (entities, numerics, jargon, forward refs, clause depth) | v1.8.0 |
 | `content_decay.py` | GSC content-decay detector: 20%+ QoQ decline | v1.10.0 |
 | `discourse_research.py` | Discourse-brief synthesis from SERP JSON; depth-bounded parsing; path-traversal guards | v1.8.0 |
-| `generate_hero.py` | Hero image ladder: Banana MCP -> Gemini API -> Unsplash/Pexels/Pixabay -> Openverse | v1.9.0 |
+| `generate_hero.py` | Hero image ladder: Banana MCP -> Gemini API -> Atlas Cloud -> Unsplash/Pexels/Pixabay -> Openverse | v1.9.0 |
 | `load_untrusted_root.py` | Code-enforced BRAND/VOICE/DISCOURSE fencing with CSPRNG nonces; O_NOFOLLOW + size cap | v1.8.3 |
 | `lint_prose.py` | Fence-aware prose-hygiene linter (no em-dash, en-dash, ` -- `); CI-enforced | v1.8.4 |
 | `quality_gate.py` | Pre-commit gate: block posts scoring < 70 | v1.10.0 |

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -222,9 +222,10 @@ done
 
 ## Optional: AI Image Generation
 
-`claude-blog` can generate custom blog images via Gemini AI (hero images, inline
-illustrations, social cards). This requires the nanobanana-mcp server and a free
-Google AI API key.
+`claude-blog` can generate custom blog images via Gemini AI or Atlas Cloud
+(hero images, inline illustrations, social cards). Gemini uses the
+nanobanana-mcp server and a Google AI API key. Atlas Cloud is an optional
+fallback for the direct hero-image script.
 
 ### Setup
 
@@ -234,6 +235,11 @@ python3 skills/blog-image/scripts/setup_image_mcp.py --key YOUR_KEY
 
 # Verify setup
 python3 skills/blog-image/scripts/validate_image_setup.py
+
+# Optional Atlas Cloud fallback for scripts/generate_hero.py
+export ATLASCLOUD_API_KEY="your-atlas-key"
+# Optional model override
+export ATLASCLOUD_IMAGE_MODEL="google/nano-banana-2-lite/text-to-image"
 ```
 
 ### Requirements
@@ -242,6 +248,7 @@ python3 skills/blog-image/scripts/validate_image_setup.py
 |-------------|---------|---------|
 | Node.js | 18+ | Runs `npx @ycse/nanobanana-mcp` |
 | Google AI API key | Free tier | Image generation via Gemini |
+| Atlas Cloud API key | Optional | Image generation when Gemini is unavailable |
 
 Without this setup, all `/blog` commands work normally using stock photos from
 Pixabay/Unsplash/Pexels. AI image generation is an optional enhancement.

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -17,6 +17,7 @@ When you explicitly invoke certain commands, the plugin may interact with extern
 | Feature | Service | When |
 |---------|---------|------|
 | AI image generation | Google Gemini API (via nanobanana-mcp) | Only when you run `/blog image` and have configured your own API key |
+| Hero image generation | Atlas Cloud API | Only when `scripts/generate_hero.py` reaches the optional Atlas fallback and you have configured `ATLASCLOUD_API_KEY` |
 | Audio narration | Google Gemini TTS API | Only when you run `/blog audio` and have configured your own API key |
 | Web research and fetching | Search engines, public web pages | Used by most commands for research, SERP analysis, link verification, and source checking (`/blog write`, `/blog rewrite`, `/blog analyze`, `/blog brief`, `/blog outline`, `/blog strategy`, `/blog seo-check`, `/blog factcheck`, `/blog geo`, `/blog calendar`, `/blog persona`, `/blog cannibalization`) |
 | SERP and keyword data | DataForSEO API (~$0.01/call) | Only when you run `/blog cannibalization --api` with your own DataForSEO credentials. Local mode (default) requires no API |

--- a/scripts/blog_preflight.py
+++ b/scripts/blog_preflight.py
@@ -478,6 +478,7 @@ def gate_1_capability_discovery(draft_dir: Path, live_tools: list[str] | None = 
     live_tools = live_tools or []
     env_keys = {
         "GOOGLE_AI_API_KEY": bool(os.environ.get("GOOGLE_AI_API_KEY")),
+        "ATLASCLOUD_API_KEY": bool(os.environ.get("ATLASCLOUD_API_KEY")),
         "UNSPLASH_ACCESS_KEY": bool(os.environ.get("UNSPLASH_ACCESS_KEY")),
         "PEXELS_API_KEY": bool(os.environ.get("PEXELS_API_KEY")),
         "PIXABAY_API_KEY": bool(os.environ.get("PIXABAY_API_KEY")),
@@ -501,6 +502,7 @@ def gate_1_capability_discovery(draft_dir: Path, live_tools: list[str] | None = 
     configured_image_paths = (
         any("nanobanana" in tool.lower() or "banana" in tool.lower() for tool in live_tools)
         or env_keys["GOOGLE_AI_API_KEY"]
+        or env_keys["ATLASCLOUD_API_KEY"]
         or env_keys["UNSPLASH_ACCESS_KEY"]
         or env_keys["PEXELS_API_KEY"]
         or env_keys["PIXABAY_API_KEY"]

--- a/scripts/generate_hero.py
+++ b/scripts/generate_hero.py
@@ -3,15 +3,16 @@
 
 Implements the v1.9.0 Blog Delivery Contract hero-image ladder. The
 orchestrator handles step 1 (Banana MCP) when available; this script
-handles steps 2-4 and produces the final `hero.<ext>` + `hero-credit.txt`
+handles steps 2-5 and produces the final `hero.<ext>` + `hero-credit.txt`
 in the requested output directory.
 
 Ladder:
   1. (Orchestrator only) Banana MCP via nanobanana-mcp
   2. Direct Gemini API via google-genai SDK (requires GOOGLE_AI_API_KEY)
-  3. Premium stock APIs: Unsplash, Pexels, Pixabay (any one key suffices)
-  4. Openverse public API (CC-licensed; no key required)
-  5. Exit nonzero with setup instructions
+  3. Atlas Cloud image API (requires ATLASCLOUD_API_KEY)
+  4. Premium stock APIs: Unsplash, Pexels, Pixabay (any one key suffices)
+  5. Openverse public API (CC-licensed; no key required)
+  6. Exit nonzero with setup instructions
 
 Usage:
     python3 scripts/generate_hero.py --topic "<title>" --tags "a,b,c" \\
@@ -33,6 +34,7 @@ import re
 import socket
 import sys
 import tempfile
+import time
 import urllib.parse
 import urllib.request
 from pathlib import Path
@@ -53,6 +55,14 @@ OUTPUT_FILE_PREFIX = "hero"
 DEFAULT_WIDTH = 1200
 DEFAULT_HEIGHT = 630
 DEFAULT_GEMINI_MODEL = os.environ.get("NANOBANANA_MODEL") or "gemini-3.1-flash-image"
+DEFAULT_ATLAS_MODEL = (
+    os.environ.get("ATLASCLOUD_IMAGE_MODEL")
+    or "google/nano-banana-2-lite/text-to-image"
+)
+ATLAS_API_BASE = os.environ.get(
+    "ATLASCLOUD_MEDIA_API_BASE", "https://api.atlascloud.ai/api/v1"
+).rstrip("/")
+ATLAS_POLL_DELAYS = (1, 2, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4)
 OPENVERSE_API = "https://api.openverse.engineering/v1/images/"
 UNSPLASH_API = "https://api.unsplash.com/search/photos"
 PEXELS_API = "https://api.pexels.com/v1/search"
@@ -369,6 +379,47 @@ def _http_get_json(url: str, headers: Optional[dict] = None) -> Optional[dict]:
         return None
 
 
+def _http_post_json(url: str, payload: dict, headers: Optional[dict] = None) -> Optional[dict]:
+    """POST JSON exactly once with the same URL and response guards as GET."""
+    ok, reason, host, port, infos = _resolve_public_url(url)
+    if not ok or host is None or port is None:
+        print(f"[http] refused (scheme/host policy): {_url_for_log(url)} ({reason})", file=sys.stderr)
+        return None
+    body = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=body,
+        headers={
+            "User-Agent": USER_AGENT,
+            "Content-Type": "application/json",
+            **(headers or {}),
+        },
+        method="POST",
+    )
+    try:
+        with _PinnedDNS(host, port, infos):
+            with _NO_REDIRECT_OPENER.open(req, timeout=HTTP_TIMEOUT) as resp:
+                status = getattr(resp, "status", 200)
+                if 300 <= int(status) < 400:
+                    print(f"[http] redirect refused: {_url_for_log(url)}", file=sys.stderr)
+                    return None
+                raw = resp.read(MAX_IMAGE_BYTES + 1)
+                if len(raw) > MAX_IMAGE_BYTES:
+                    print(
+                        f"[http] response exceeds {MAX_IMAGE_BYTES} bytes; refusing",
+                        file=sys.stderr,
+                    )
+                    return None
+    except Exception as e:
+        print(f"[http] POST {_url_for_log(url)}: {e}", file=sys.stderr)
+        return None
+    try:
+        return json.loads(raw.decode("utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError) as e:
+        print(f"[http] json decode failed: {e}", file=sys.stderr)
+        return None
+
+
 def _try_gemini(topic: str, tags: list[str], out_dir: Path, width: int, height: int, model: str) -> Optional[dict]:
     """Ladder step 2: direct Gemini API."""
     api_key = os.environ.get("GOOGLE_AI_API_KEY")
@@ -424,6 +475,83 @@ def _try_gemini(topic: str, tags: list[str], out_dir: Path, width: int, height: 
         f"AI-generated via {used_model}. No attribution required.\nPrompt: {prompt}\n",
     )
     return {"source": "gemini", "model": used_model, "path": str(hero_path)}
+
+
+def _try_atlas(
+    topic: str,
+    tags: list[str],
+    out_dir: Path,
+    width: int,
+    height: int,
+    model: str,
+) -> Optional[dict]:
+    """Ladder step 3: Atlas Cloud async image generation."""
+    api_key = os.environ.get("ATLASCLOUD_API_KEY")
+    if not api_key:
+        return None
+
+    prompt = _build_prompt(topic, tags, width, height)
+    headers = {"Authorization": f"Bearer {api_key}"}
+    submitted = _http_post_json(
+        f"{ATLAS_API_BASE}/model/generateImage",
+        {
+            "model": model,
+            "prompt": prompt,
+            "aspect_ratio": "16:9",
+            "resolution": "1k",
+        },
+        headers=headers,
+    )
+    if not submitted or str(submitted.get("code", "200")) != "200":
+        print("[atlas] image submission failed", file=sys.stderr)
+        return None
+
+    prediction = submitted.get("data") or submitted
+    prediction_id = prediction.get("id") if isinstance(prediction, dict) else None
+    if not prediction_id:
+        print("[atlas] image submission returned no prediction id", file=sys.stderr)
+        return None
+
+    output_url: Optional[str] = None
+    for delay in ATLAS_POLL_DELAYS:
+        time.sleep(delay)
+        polled = _http_get_json(
+            f"{ATLAS_API_BASE}/model/prediction/{urllib.parse.quote(str(prediction_id), safe='')}",
+            headers=headers,
+        )
+        if not polled or str(polled.get("code", "200")) != "200":
+            continue
+        result = polled.get("data") or polled
+        if not isinstance(result, dict):
+            continue
+        status = str(result.get("status") or "").lower()
+        if status in {"failed", "timeout", "canceled", "cancelled"}:
+            print(f"[atlas] prediction ended with status {status}", file=sys.stderr)
+            return None
+        if status in {"completed", "succeeded"}:
+            outputs = result.get("outputs") or []
+            if outputs and isinstance(outputs[0], str):
+                output_url = outputs[0]
+            break
+
+    if not output_url:
+        print("[atlas] prediction did not complete within the polling window", file=sys.stderr)
+        return None
+    img_bytes = _download_image(output_url)
+    if not img_bytes:
+        return None
+    try:
+        img_bytes = _fit_image_bytes(img_bytes, width, height)
+    except RuntimeError as e:
+        print(f"[image] {e}", file=sys.stderr)
+        return None
+    hero_path = out_dir / f"{OUTPUT_FILE_PREFIX}{_image_ext(img_bytes, '.png')}"
+    _atomic_write_bytes(hero_path, img_bytes)
+    _atomic_write_text(
+        out_dir / "hero-credit.txt",
+        f"AI-generated via Atlas Cloud model {model}. No attribution required.\nPrompt: {prompt}\n",
+    )
+    return {"source": "atlas", "model": model, "path": str(hero_path)}
 
 
 def _try_unsplash(query: str, out_dir: Path, width: int, height: int) -> Optional[dict]:
@@ -584,6 +712,11 @@ def main() -> int:
     parser.add_argument("--width", type=int, default=DEFAULT_WIDTH)
     parser.add_argument("--height", type=int, default=DEFAULT_HEIGHT)
     parser.add_argument("--model", default=DEFAULT_GEMINI_MODEL, help="Gemini image model name")
+    parser.add_argument(
+        "--atlas-model",
+        default=DEFAULT_ATLAS_MODEL,
+        help="Atlas Cloud image model name",
+    )
     parser.add_argument("--json", action="store_true", help="Emit JSON result to stdout")
     args = parser.parse_args()
 
@@ -625,6 +758,9 @@ def main() -> int:
 
     ladder: list[tuple[str, Callable[[], Optional[dict]]]] = [
         ("gemini", lambda: _try_gemini(args.topic, tags, out_dir, args.width, args.height, args.model)),
+        ("atlas", lambda: _try_atlas(
+            args.topic, tags, out_dir, args.width, args.height, args.atlas_model
+        )),
         ("premium-stock", lambda: _try_premium_stock(args.topic, tags, out_dir, args.width, args.height)),
         ("openverse", lambda: _try_openverse(args.topic, tags, out_dir, args.width, args.height)),
     ]
@@ -650,7 +786,8 @@ def main() -> int:
         "error": "no-image-gen-path",
         "message": (
             "Hero image required but no generation path available. Configure Banana MCP, "
-            "set GOOGLE_AI_API_KEY, set UNSPLASH_ACCESS_KEY / PEXELS_API_KEY / PIXABAY_API_KEY, "
+            "set GOOGLE_AI_API_KEY or ATLASCLOUD_API_KEY, set "
+            "UNSPLASH_ACCESS_KEY / PEXELS_API_KEY / PIXABAY_API_KEY, "
             "or place a 1200x630 hero.png in the draft folder manually."
         ),
     }

--- a/skills/blog/references/blog-delivery-contract.md
+++ b/skills/blog/references/blog-delivery-contract.md
@@ -23,7 +23,7 @@ Runs once at the start of `/blog write` or `/blog rewrite`. Enumerates the proje
 ### What gets enumerated
 
 - **MCP servers loaded**: `nanobanana-mcp`, `dataforseo-mcp`, others. Detected via tool availability, not by reading `.mcp.json` (the file may declare servers that failed to start).
-- **Env vars present**: `GOOGLE_AI_API_KEY`, `UNSPLASH_ACCESS_KEY`, `PEXELS_API_KEY`, `PIXABAY_API_KEY`. Key names only; values never read or logged.
+- **Env vars present**: `GOOGLE_AI_API_KEY`, `ATLASCLOUD_API_KEY`, `UNSPLASH_ACCESS_KEY`, `PEXELS_API_KEY`, `PIXABAY_API_KEY`. Key names only; values never read or logged.
 - **Optional Python deps**: `patchright`, `weasyprint`, `google-genai`, `requests`. Probed via `importlib.util.find_spec()`.
 - **Project-root context files**: `BRAND.md`, `VOICE.md`, `DISCOURSE.md`. Loaded only via the trusted installed `load_untrusted_root.py` helper.
 - **Agents available**: `blog-reviewer` is mandatory; `blog-researcher`, `blog-writer`, `blog-seo`, `blog-translator` are optional.
@@ -31,7 +31,7 @@ Runs once at the start of `/blog write` or `/blog rewrite`. Enumerates the proje
 
 ### Failure modes
 
-- **No hero path at all** (no valid local `hero.png` or `.jpg`, no Banana MCP, no Gemini key, no stock API key, and Openverse unreachable): BLOCK with explicit setup instructions.
+- **No hero path at all** (no valid local `hero.png` or `.jpg`, no Banana MCP, no Gemini or Atlas Cloud key, no stock API key, and Openverse unreachable): BLOCK with explicit setup instructions.
 - **Reviewer agent missing**: BLOCK. Cannot enforce Gate 4 without it.
 - **Capability declared but unused**: WARN (informational, not blocking). Example: `dataforseo-mcp` is loaded but the post topic doesn't need keyword research.
 
@@ -115,11 +115,12 @@ Tried in order. First success wins. Skip steps for capabilities not available pe
 
 1. **Banana MCP** (`nanobanana-mcp` loaded as a tool, not just declared in `.mcp.json`): call its `generate_image` tool with an optimized six-component prompt (Subject + Action + Context + Composition + Lighting + Style) targeting 1200×630.
 2. **Direct Gemini API** (`GOOGLE_AI_API_KEY` present, MCP not loaded): call the `google-genai` SDK with `gemini-3.1-flash-image` by default. Fallback, in order, to `gemini-3.1-flash-lite-image` and `gemini-3-pro-image`. See `https://ai.google.dev/gemini-api/docs/image-generation`.
-3. **Premium stock APIs** (`UNSPLASH_ACCESS_KEY`, `PEXELS_API_KEY`, or `PIXABAY_API_KEY` present): search via the official API using post title + top tags as query. Do not scrape or construct raw CDN URLs. Capture each source's license metadata and attribution requirements, download the asset locally, and write `hero-credit.txt`. Unsplash, Pexels, and Pixabay use their own licenses; do not treat them as CC sources.
-4. **Openverse public API** (no key required): `GET https://api.openverse.org/v1/images/?q=<query>&aspect_ratio=wide&license=cc0,by`. Pick the top relevance match with complete attribution. Always download to `hero.<ext>` plus `hero-credit.txt` for CC attribution.
-5. **Block with clear error**: "Hero image required but no generation path available. Configure Banana MCP, set GOOGLE_AI_API_KEY, set UNSPLASH/PEXELS/PIXABAY key, or place a 1200×630 hero.png in the draft folder manually."
+3. **Atlas Cloud API** (`ATLASCLOUD_API_KEY` present): submit one image task, poll the prediction endpoint with bounded delays, and download the completed output. `ATLASCLOUD_IMAGE_MODEL` may override the default model. Submission is never retried automatically.
+4. **Premium stock APIs** (`UNSPLASH_ACCESS_KEY`, `PEXELS_API_KEY`, or `PIXABAY_API_KEY` present): search via the official API using post title + top tags as query. Do not scrape or construct raw CDN URLs. Capture each source's license metadata and attribution requirements, download the asset locally, and write `hero-credit.txt`. Unsplash, Pexels, and Pixabay use their own licenses; do not treat them as CC sources.
+5. **Openverse public API** (no key required): `GET https://api.openverse.org/v1/images/?q=<query>&aspect_ratio=wide&license=cc0,by`. Pick the top relevance match with complete attribution. Always download to `hero.<ext>` plus `hero-credit.txt` for CC attribution.
+6. **Block with clear error**: "Hero image required but no generation path available. Configure Banana MCP, set GOOGLE_AI_API_KEY or ATLASCLOUD_API_KEY, set UNSPLASH/PEXELS/PIXABAY key, or place a 1200×630 hero.png in the draft folder manually."
 
-Implementation: `scripts/generate_hero.py`. Always writes `hero-credit.txt` next to `hero.<ext>` for attribution compliance, even when generation paths 1-2 (AI-generated, no attribution needed) are used. The file then contains "AI-generated; no attribution required."
+Implementation: `scripts/generate_hero.py`. Always writes `hero-credit.txt` next to `hero.<ext>` for attribution compliance, even when generation paths 1-3 (AI-generated, no attribution needed) are used. The file then contains "AI-generated; no attribution required."
 
 ## Iteration Loop
 

--- a/tests/test_generate_hero_atlas.py
+++ b/tests/test_generate_hero_atlas.py
@@ -1,0 +1,242 @@
+"""Atlas Cloud provider tests for scripts/generate_hero.py."""
+from __future__ import annotations
+
+import importlib.util
+import socket
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+HERO_PATH = ROOT / "scripts" / "generate_hero.py"
+PREFLIGHT_PATH = ROOT / "scripts" / "blog_preflight.py"
+
+
+@pytest.fixture()
+def hero_module():
+    name = "generate_hero_atlas_test"
+    spec = importlib.util.spec_from_file_location(name, HERO_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture()
+def preflight_module():
+    name = "blog_preflight_atlas_test"
+    spec = importlib.util.spec_from_file_location(name, PREFLIGHT_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_atlas_is_skipped_without_api_key(hero_module, monkeypatch, tmp_path):
+    monkeypatch.delenv("ATLASCLOUD_API_KEY", raising=False)
+    monkeypatch.setattr(
+        hero_module,
+        "_http_post_json",
+        lambda *args, **kwargs: pytest.fail("Atlas POST should not run without a key"),
+    )
+
+    assert hero_module._try_atlas(
+        "Topic", [], tmp_path, 1200, 630, hero_module.DEFAULT_ATLAS_MODEL
+    ) is None
+
+
+def test_preflight_reports_atlas_key_without_exposing_value(
+    preflight_module, monkeypatch, tmp_path
+):
+    monkeypatch.setenv("ATLASCLOUD_API_KEY", "secret-value-not-for-output")
+
+    result = preflight_module.gate_1_capability_discovery(tmp_path, live_tools=[])
+    capabilities = result["capabilities"]
+
+    assert capabilities["env_keys_present"]["ATLASCLOUD_API_KEY"] is True
+    serialized = (tmp_path / "capabilities.json").read_text(encoding="utf-8")
+    assert "secret-value-not-for-output" not in serialized
+
+
+def test_atlas_submits_once_polls_and_writes_hero(hero_module, monkeypatch, tmp_path):
+    monkeypatch.setenv("ATLASCLOUD_API_KEY", "test-key")
+    submitted = []
+    polls = iter(
+        [
+            {"code": 200, "data": {"status": "processing"}},
+            {
+                "code": 200,
+                "data": {
+                    "status": "completed",
+                    "outputs": ["https://cdn.example.test/hero.png"],
+                },
+            },
+        ]
+    )
+
+    def fake_post(url, payload, headers=None):
+        submitted.append((url, payload, headers))
+        return {"code": 200, "data": {"id": "prediction-123"}}
+
+    monkeypatch.setattr(hero_module, "_http_post_json", fake_post)
+    monkeypatch.setattr(hero_module, "_http_get_json", lambda *args, **kwargs: next(polls))
+    monkeypatch.setattr(hero_module, "_download_image", lambda url: b"\x89PNG\r\n\x1a\nimage")
+    monkeypatch.setattr(hero_module, "_fit_image_bytes", lambda data, width, height: data)
+    monkeypatch.setattr(hero_module.time, "sleep", lambda delay: None)
+
+    model = "google/nano-banana-2-lite/text-to-image"
+    result = hero_module._try_atlas(
+        "Reliable systems", ["engineering"], tmp_path, 1200, 630, model
+    )
+
+    assert len(submitted) == 1
+    _, payload, headers = submitted[0]
+    assert payload == {
+        "model": model,
+        "prompt": hero_module._build_prompt(
+            "Reliable systems", ["engineering"], 1200, 630
+        ),
+        "aspect_ratio": "16:9",
+        "resolution": "1k",
+    }
+    assert headers == {"Authorization": "Bearer test-key"}
+    assert result == {
+        "source": "atlas",
+        "model": model,
+        "path": str(tmp_path / "hero.png"),
+    }
+    assert (tmp_path / "hero.png").read_bytes().startswith(b"\x89PNG")
+    credit = (tmp_path / "hero-credit.txt").read_text(encoding="utf-8")
+    assert "Atlas Cloud" in credit
+    assert model in credit
+
+
+def test_atlas_post_refuses_private_destination(hero_module, monkeypatch):
+    monkeypatch.setattr(
+        hero_module.socket,
+        "gethostbyname",
+        lambda host: "127.0.0.1",
+    )
+    monkeypatch.setattr(
+        hero_module._NO_REDIRECT_OPENER,
+        "open",
+        lambda *args, **kwargs: pytest.fail("private destinations must not be opened"),
+    )
+
+    assert hero_module._http_post_json(
+        "https://atlas.example.test/api/v1/model/generateImage",
+        {"model": "example", "prompt": "example"},
+    ) is None
+
+
+def test_atlas_post_pins_validated_dns(hero_module, monkeypatch):
+    public_info = [
+        (
+            socket.AF_INET,
+            socket.SOCK_STREAM,
+            socket.IPPROTO_TCP,
+            "",
+            ("93.184.216.34", 443),
+        )
+    ]
+    private_info = [
+        (
+            socket.AF_INET,
+            socket.SOCK_STREAM,
+            socket.IPPROTO_TCP,
+            "",
+            ("169.254.169.254", 443),
+        )
+    ]
+    dns_calls = 0
+
+    def fake_getaddrinfo(host, port, proto=0, *args, **kwargs):
+        nonlocal dns_calls
+        dns_calls += 1
+        return public_info if dns_calls == 1 else private_info
+
+    class FakeResponse:
+        status = 200
+
+        def read(self, size=None):
+            return b'{"code":200,"data":{"id":"prediction-123"}}'
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+    def fake_open(request, timeout=None):
+        assert hero_module.socket.getaddrinfo(
+            "atlas.example.test", 443, proto=socket.IPPROTO_TCP
+        ) == public_info
+        return FakeResponse()
+
+    monkeypatch.setattr(
+        hero_module.socket,
+        "gethostbyname",
+        lambda host: "93.184.216.34",
+    )
+    monkeypatch.setattr(hero_module.socket, "getaddrinfo", fake_getaddrinfo)
+    monkeypatch.setattr(hero_module._NO_REDIRECT_OPENER, "open", fake_open)
+
+    result = hero_module._http_post_json(
+        "https://atlas.example.test/api/v1/model/generateImage",
+        {"model": "example", "prompt": "example"},
+    )
+
+    assert result == {"code": 200, "data": {"id": "prediction-123"}}
+    assert hero_module.socket.getaddrinfo is fake_getaddrinfo
+
+
+def test_atlas_failed_prediction_stops_without_download(hero_module, monkeypatch, tmp_path):
+    monkeypatch.setenv("ATLASCLOUD_API_KEY", "test-key")
+    monkeypatch.setattr(
+        hero_module,
+        "_http_post_json",
+        lambda *args, **kwargs: {"code": 200, "data": {"id": "prediction-123"}},
+    )
+    monkeypatch.setattr(
+        hero_module,
+        "_http_get_json",
+        lambda *args, **kwargs: {"code": 200, "data": {"status": "failed"}},
+    )
+    monkeypatch.setattr(hero_module.time, "sleep", lambda delay: None)
+    monkeypatch.setattr(
+        hero_module,
+        "_download_image",
+        lambda url: pytest.fail("failed predictions must not download an output"),
+    )
+
+    assert hero_module._try_atlas(
+        "Topic", [], tmp_path, 1200, 630, hero_module.DEFAULT_ATLAS_MODEL
+    ) is None
+
+
+def test_existing_gemini_path_still_precedes_atlas(hero_module, monkeypatch, tmp_path):
+    calls = []
+    monkeypatch.setattr(
+        hero_module,
+        "_try_gemini",
+        lambda *args: calls.append("gemini") or {
+            "source": "gemini",
+            "path": str(tmp_path / "hero.png"),
+        },
+    )
+    monkeypatch.setattr(
+        hero_module,
+        "_try_atlas",
+        lambda *args: calls.append("atlas") or pytest.fail(
+            "Atlas should not run after Gemini succeeds"
+        ),
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["generate_hero.py", "--topic", "Topic", "--out", str(tmp_path)],
+    )
+
+    assert hero_module.main() == 0
+    assert calls == ["gemini"]


### PR DESCRIPTION
## Summary

- add Atlas Cloud as an optional hero-image fallback after the existing Gemini path
- submit image generation once, poll prediction state with bounded delays, and validate downloaded output through the existing SSRF and image guards
- expose Atlas capability discovery and document configuration, privacy, architecture, and the network trust boundary

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior; explain below)
- [ ] Documentation update
- [ ] Security fix
- [ ] Refactor / chore (no functional change)

## Linked issue

N/A

## Test plan
- [x] Existing tests pass (`.venv/bin/python -m pytest -q tests`: 325 passed, 1 skipped)
- [x] New tests added for new behavior
- [x] `claude plugin validate .` passes
- [ ] Manual paid generation completed
- [x] No new U+2014, U+2013, or ` -- ` in prose; matches project style

Live Atlas model catalog and schema GETs were validated for `google/nano-banana-2-lite/text-to-image`. No billable generation POST was made.

## Documentation
- [x] Docs updated (`CHANGELOG.md`, architecture, installation, privacy, delivery contract)
- [ ] CONTRIBUTORS.md updated if a third-party methodology was adapted
- [x] No version-count drift

## Security checklist (if applicable)
- [x] No new hardcoded secrets, API keys, or credentials
- [x] No new `Bash` tool grants in agent frontmatter
- [x] No new `allowed-tools` field
- [x] Trust boundary documented in `.github/SECURITY.md`

## Contributor reference
See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, code style, and PR guidelines.